### PR TITLE
휴면계정 -> 회원가입, 재로그인 시 발생하는 오류 수정

### DIFF
--- a/src/main/java/com/project/contap/model/user/CostomUserRepository.java
+++ b/src/main/java/com/project/contap/model/user/CostomUserRepository.java
@@ -14,4 +14,5 @@ public interface CostomUserRepository {
     Boolean existUserByUserName(String userName);
     Boolean existUserByPhoneNumber(String phoneNumber);
     Long getActiveUsercnt();
+    Boolean existUserByEmailAndUserStatus(String email);
 }

--- a/src/main/java/com/project/contap/model/user/UserRepositoryImpl.java
+++ b/src/main/java/com/project/contap/model/user/UserRepositoryImpl.java
@@ -184,4 +184,12 @@ public class UserRepositoryImpl implements CostomUserRepository{
                 .where(qUser.userStatus.eq(UserStatusEnum.ACTIVE))
                 .fetchCount();
     }
+
+    @Override
+    public Boolean existUserByEmailAndUserStatus(String email) {
+        QUser qUser = QUser.user;
+        return queryFactory.select(qUser.id).from(qUser)
+                .where(qUser.userStatus.eq(UserStatusEnum.ACTIVE))
+                .fetchFirst() != null;
+    }
 }

--- a/src/main/java/com/project/contap/service/EmailService.java
+++ b/src/main/java/com/project/contap/service/EmailService.java
@@ -10,10 +10,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.mail.MailException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
+
 import javax.mail.MessagingException;
 import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeMessage;
-
 import java.io.UnsupportedEncodingException;
 
 import static com.project.contap.common.util.RandomNumberGeneration.makeRandomNumber;
@@ -32,7 +32,7 @@ public class EmailService {
 
         String validatedEmail = email.replaceAll(" ", "");
 
-        if (userRepository.existsByEmail(validatedEmail)) {
+        if (userRepository.existUserByEmailAndUserStatus(validatedEmail)) {
             throw new RuntimeException("이미 사용 중인 이메일 입니다.");
         }
 

--- a/src/main/java/com/project/contap/service/UserService.java
+++ b/src/main/java/com/project/contap/service/UserService.java
@@ -63,6 +63,11 @@ public class UserService {
         if (!passwordEncoder.matches(requestDto.getPw(), user.getPw()))
             throw new ContapException(ErrorCode.NOT_EQUAL_PASSWORD);
 
+        if(user.getUserStatus()==UserStatusEnum.INACTIVE) {
+            user.setUserStatus(UserStatusEnum.ACTIVE);
+            userRepository.save(user);
+        }
+
         return user;
     }
 


### PR DESCRIPTION
1. 휴면계정 -> 회원가입 시 
 - 이메일 보낼 경우 '이미 사용 중인 이메일입니다.' -> 오류 수정
2. 휴면계정 -> 재로그인 시
  - 로그인은 정상적으로 되나, 다른 페이지에서 '권한이 없습니다.' 오류 수정